### PR TITLE
fixed problem that prevented using the pod in the latest version of XCode + Swift

### DIFF
--- a/GPX/GPX.h
+++ b/GPX/GPX.h
@@ -6,6 +6,7 @@
 //  Copyright (c) 2012 NextBusinessSystem Co., Ltd. All rights reserved.
 //
 
+#import <UIKit/UIKit.h>
 #import "GPXParser.h"
 #import "GPXConst.h"
 #import "GPXType.h"

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ track.name = @"My New Track";
 
 # Usage with Swift
  
-In order to use it with the new Swift programming language you need to use the [Objective-C Bridging header] (https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html). 
+In order to use this library with the new Swift programming language you need to use the [Objective-C Bridging header] (https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html). 
 
-Basically, you have to create a .h file that imports GPX.h
+Basically, you have to create a .h file that imports *GPX.h*
 
 ```objc
 // <YourProjectName>/Bridge.h
@@ -74,7 +74,7 @@ Basically, you have to create a .h file that imports GPX.h
  
  #endif
 ```
-Then in Build Settings of your project name search for the key "Objective-C Bridging header" and add that file ie: <YourProjectName>/Bridge.h
+Then in Build Settings of your project name search for the key **"Objective-C Bridging header"** and add that file ie: *YourProjectName/Bridge.h*
   
 That's it.
  

--- a/README.md
+++ b/README.md
@@ -22,17 +22,19 @@ iOS-KML-Framework is available through [CocoaPods](http://cocoapods.org), to ins
 it simply add the following line to your Podfile:
 
 ```ruby
-platform :ios, '5.1'
+platform :ios, '6.0'
 pod 'iOS-GPX-Framework', "~> 0.0"
 ```
 
+ Source files of the podified version are [on this repository](https://github.com/Pierre-Loup/iOS-GPX-Framework)
+ 
 Usage
 ---------------------------------
 
 ```objc
 //Import the umbrella header
 
-#import "KML.h"
+#import "GPX.h"
 
 
 //To parsing the GPX file, simply call the parse method :
@@ -56,7 +58,27 @@ track.name = @"My New Track";
 [track newTrackpointWithLatitude:35.828609f longitude:139.745447f];
 ```
 
+# Usage with Swift
+ 
+In order to use it with the new Swift programming language you need to use the [Objective-C Bridging header] (https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/BuildingCocoaApps/MixandMatch.html). 
 
+Basically, you have to create a .h file that imports GPX.h
+
+```objc
+// <YourProjectName>/Bridge.h
+ 
+ #ifndef GpxTest_Bridge_h
+ #define GpxTest_Bridge_h
+ 
+   #import "GPX.h"
+ 
+ #endif
+```
+Then in Build Settings of your project name search for the key "Objective-C Bridging header" and add that file ie: <YourProjectName>/Bridge.h
+  
+That's it.
+ 
+ 
 ## Requirements
 
 - iOS 6.0 or later
@@ -64,6 +86,8 @@ track.name = @"My New Track";
 ## Author
 
 Watanabe Toshinori, t@flcl.jp
+
+Cocoapod version created by [@Pierre-Loup](https://github.com/Pierre-Loup/)
 
 ## License
 

--- a/iOS-GPX-Framework.podspec
+++ b/iOS-GPX-Framework.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name         = "iOS-GPX-Framework"
-  s.version      = "0.0.2"
+  s.version      = "0.0.3"
   s.summary      = "The iOS framework for parsing/generating GPX files."
   s.description  = <<-DESC
-                   This is a iOS framework for parsing/generating GPX files. 
+                   This is a iOS framework for parsing/generating GPX files.
                    This Framework parses the GPX from a URL or Strings and create Objective-C Instances of GPX structure.
                    DESC
   s.homepage     = "http://gpxframework.com/"
@@ -11,12 +11,16 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.author       = { "Watanabe Toshinori" => "t@flcl.jp" }
   s.source       = { :git => "https://github.com/Pierre-Loup/iOS-GPX-Framework.git", :tag => s.version.to_s  }
-  
+
   s.platform     = :ios
   s.ios.deployment_target = '6.0'
   s.requires_arc = true
 
+  s.xcconfig = {
+      'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/GPX/"'
+    }
+
   s.source_files = 'GPX'
-  s.ios.framework = 'UIKit'  
+  s.ios.framework = 'UIKit'
   s.dependency 'TBXML', '~> 1.5'
 end

--- a/iOS-GPX-Framework.podspec
+++ b/iOS-GPX-Framework.podspec
@@ -1,23 +1,23 @@
 Pod::Spec.new do |s|
   s.name         = "iOS-GPX-Framework"
-  s.version      = "0.0.3"
-  s.summary      = "The iOS framework for parsing/generating GPX files."
+  s.version      = "0.0.4"
+  s.summary      = "The iOS framework for parsing/generating GPX files. (@merlos fork)"
   s.description  = <<-DESC
                    This is a iOS framework for parsing/generating GPX files.
                    This Framework parses the GPX from a URL or Strings and create Objective-C Instances of GPX structure.
                    DESC
-  s.homepage     = "http://gpxframework.com/"
+  s.homepage     = "https://github.com/merlos/iOS-GPX-Framework."
   s.screenshots  = "http://gpxframework.com/img/gpx_viewer.png", "http://gpxframework.com/img/gpx_logger.png"
   s.license      = 'MIT'
-  s.author       = { "Watanabe Toshinori" => "t@flcl.jp" }
-  s.source       = { :git => "https://github.com/Pierre-Loup/iOS-GPX-Framework.git", :tag => s.version.to_s  }
+  s.author       = { "Watanabe Toshinori" => "t@flcl.jp", "Juan M. Merlos" => '' }
+  s.source       = { :git => "https://github.com/merlos/iOS-GPX-Framework.git", :tag => s.version.to_s  }
 
   s.platform     = :ios
   s.ios.deployment_target = '6.0'
   s.requires_arc = true
 
   s.xcconfig = {
-      'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/GPX/"'
+      'USER_HEADER_SEARCH_PATHS' => '"${PODS_ROOT}/iOS-GPX-Framework/GPX"'
     }
 
   s.source_files = 'GPX'


### PR DESCRIPTION
Hi Pierre,

Trying to use the pod in a swift project I got the error you can se on the screenshot:

![problem](https://cloud.githubusercontent.com/assets/404446/4265170/9f47fb64-3c41-11e4-8502-9b8a65c431f2.png)

To reproduce the problem:
1.- Create a swift project.
2.- Add iOS-GPX-Framework in your podfile.
3.- Add the Objective-C Header Bride
4.- Build.

The fix is just add UIKit to GPX.h

Also, I've included also some doc in the readme on how to include the pod in a swift project.

Thank you for creating the pod.
Regards, Juan.
