### PR TITLE
Fixed build error when using Swift CocoaPods

### DIFF
--- a/GPX/GPXElementSubclass.h
+++ b/GPX/GPXElementSubclass.h
@@ -7,7 +7,7 @@
 //
 
 #import "GPXElement.h"
-#import "TBXML.h"
+@import TBXML;
 
 @interface GPXElement ()
 

--- a/GPX/GPXParser.m
+++ b/GPX/GPXParser.m
@@ -10,7 +10,7 @@
 #import "GPXConst.h"
 #import "GPXElementSubclass.h"
 #import "GPXRoot.h"
-#import "TBXML.h"
+@import TBXML;
 
 @implementation GPXParser
 

--- a/iOS-GPX-Framework.podspec
+++ b/iOS-GPX-Framework.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "iOS-GPX-Framework"
-  s.version      = "0.0.4"
+  s.version      = "0.0.5"
   s.summary      = "The iOS framework for parsing/generating GPX files. (@merlos fork)"
   s.description  = <<-DESC
                    This is a iOS framework for parsing/generating GPX files.


### PR DESCRIPTION
I bumped up the version in podspec and used `@import TBXML;` instead of `#import`. This fixes the build problem for CocoaPods.